### PR TITLE
Check IF1 isFlushed when setting doRefetch in ICaches. #1

### DIFF
--- a/ZenCove/src/zencove/core/ICache.scala
+++ b/ZenCove/src/zencove/core/ICache.scala
@@ -188,7 +188,7 @@ class ICache(config: ZencoveConfig) extends Plugin[FetchPipeline] with IBus {
           // 避免IF1中指令取不到新写的cache，重取
           // 每一条都从state boot开始
           when(!arbitration.isStuck) {
-            doRefetch := True
+            doRefetch := !IF1.arbitration.isFlushed
             goto(stateBoot)
           }
         }

--- a/ZenCove/src/zencove/core/ICacheNoReorder.scala
+++ b/ZenCove/src/zencove/core/ICacheNoReorder.scala
@@ -198,7 +198,7 @@ class ICacheNoReorder(config: ZencoveConfig) extends Plugin[FetchPipeline] with 
           // 避免IF1中指令取不到新写的cache，重取
           // 每一条都从state boot开始
           when(arbitration.notStuck) {
-            doRefetch := True
+            doRefetch := !IF1.arbitration.isFlushed
             goto(stateBoot)
           }
         }


### PR DESCRIPTION
在设置doRefetch时检查IF1是否已经被冲刷可以解决问题。
与Issue中相同测例的仿真波形如下：
![image](https://github.com/zencove-thu/zencove-zoom/assets/56666778/5ea28e59-eb72-4850-ab86-f3cc2403e558)
可以看到IF1中被flushed掉的PC=0x80000114不再阻塞一个周期，而是与完成Refill的IF2阶段同时发射，保证Predict Jump生效。